### PR TITLE
Removed stacked items from player energy pool

### DIFF
--- a/data/energy/functions/v1.1/player/modify_energy_2.mcfunction
+++ b/data/energy/functions/v1.1/player/modify_energy_2.mcfunction
@@ -1,7 +1,7 @@
 
 # #player.in energy.data -> amount of energy to add/remove from the player's inv
 # #player.out energy.data <- 0 if failed, 1 if succeeded
-# item format: tag:{energy:{storage:0,max_strorage:0}}
+# item format: tag:{energy:{storage:0,max_storage:0}}
 
 #store scores
 scoreboard players operation #player.energy energy.data = #player.in energy.data
@@ -9,7 +9,7 @@ scoreboard players set #player.out energy.data 0
 
 #copy inv
 data modify storage energy:temp list set value []
-data modify storage energy:temp list append from entity @s Inventory[{tag:{energy:{}}}]
+data modify storage energy:temp list append from entity @s Inventory[{Count:1b,tag:{energy:{}}}]
 
 #loop over inv
 execute if data storage energy:temp list[0] run function energy:v1.1/player/modify_energy_3


### PR DESCRIPTION
This will prevent issues when someone stack up batteries,
because the if we use these 2 commands:
```haskell
scoreboard players set #player.in energy.data 200
function energy:v1/api/modify_player_energy
```
all the batteries will lose this amount of energy